### PR TITLE
Scan audio and video for media hook

### DIFF
--- a/src/media.js
+++ b/src/media.js
@@ -1,8 +1,8 @@
 (() => {
   if (document.querySelector("[mcx-media]") === null) {
-    for (const $video of document.querySelectorAll("video")) {
-      if (!$video.paused && !$video.muted) {
-        $video.toggleAttribute("mcx-media", true);
+    for (const $media of document.querySelectorAll("audio, video")) {
+      if (!$media.paused && !$media.muted) {
+        $media.toggleAttribute("mcx-media", true);
         window.dispatchEvent(new Event("hook"));
         return;
       }


### PR DESCRIPTION
## Summary
- Detect first playing audio or video element and tag with `mcx-media`
- Preserve override of `Audio.prototype.play`/`pause` for dynamically created audio

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx eslint src/media.js`


------
https://chatgpt.com/codex/tasks/task_e_68902005bdb0832f9c1dbfca92bee44d